### PR TITLE
Change to GPL-3.0-or-later license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Andreas Merkle", email = "andreas.merkle@newtec.de" },
     { name = "Dominik Knoll", email = "dominik.knoll@newtec.de"}
 ]
-license = "GPL-3.0-only" 
+license = "GPL-3.0-or-later" 
 classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Use GPL-3.0-or-later because the GPL-3.0-only hinders the integration and distribution of combined works.
Its compliant to https://spdx.org/licenses/