### PR TITLE
Fix TypeError when calling pyinstaller generated exe

### DIFF
--- a/src/lobster_doxygen/version.py
+++ b/src/lobster_doxygen/version.py
@@ -85,12 +85,20 @@ def init_from_toml():
     toml_file = resource_path("pyproject.toml")
     data = toml.load(toml_file)
 
+
+    # Handle license as either a string or a dictionary.
+    license_field = data["project"]["license"]
+    if isinstance(license_field, dict):
+        license_text = license_field.get("text", "???")
+    else:
+        license_text = license_field
+
     return (
         data["project"]["version"],
         data["project"]["authors"][0]["name"],
         data["project"]["authors"][0]["email"],
         data["project"]["urls"]["repository"],
-        data["project"]["license"]["text"],
+        license_text,
     )
 
 


### PR DESCRIPTION
Fix taken form #102

To be able to run the tool standalone, the lobster-doxygen.spec needs to be extended with doxmlparser as hiddenimport. The pyinstaller will not do that automatically. See https://github.com/NewTec-GmbH/lobster-doxygen/issues/49